### PR TITLE
CASMCMS-7676 Enable loading of recipes with template-dicts

### DIFF
--- a/.license_check.yaml
+++ b/.license_check.yaml
@@ -1,0 +1,25 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+add_exclude:
+  - .env/

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,7 +4,7 @@ certifi==2019.11.28
 chardet==3.0.4
 docutils==0.14
 idna==2.8
-ims-python-helper==2.7.29
+ims-python-helper==0.4.68
 jmespath==0.9.4
 oauthlib==2.1.0
 python-dateutil==2.8.1
@@ -13,3 +13,4 @@ requests==2.23.0
 requests-oauthlib==1.0.0
 s3transfer==0.3.0
 urllib3==1.25.9
+Jinja2==3.0.3

--- a/ims_load_artifacts/load_artifacts.py
+++ b/ims_load_artifacts/load_artifacts.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-# Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -13,13 +16,12 @@
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-#
-# (MIT License)
+
 """
 Cray IMS Load Artifacts Container
 This loads and registers recipes and pre-built image artifacts with IMS.
@@ -28,10 +30,12 @@ This loads and registers recipes and pre-built image artifacts with IMS.
 import logging
 import os
 import sys
+import tempfile
 import time
 from string import Template
 
 import botocore.exceptions
+import jinja2
 import requests
 import urllib3
 import yaml
@@ -44,6 +48,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 LOGGER = logging.getLogger(__name__)
 
 MANIFEST_FILE = os.environ.get("MANIFEST_FILE", "/manifest.yaml")
+TEMPLATE_DICTIONARY = os.environ.get("TEMPLATE_DICTIONARY", "/mnt/image-recipe-import/template_dictionary")
 IMS_URL = os.environ.get('IMS_URL', 'http://cray-ims').strip("/")
 S3_IMS_BUCKET = os.environ.get('S3_IMS_BUCKET', "ims")
 S3_BOOT_IMAGES_BUCKET = os.getenv('S3_BOOT_IMAGES_BUCKET', 'boot-images')
@@ -247,9 +252,10 @@ class _ImsLoadArtifacts_v1_0_0:
             linux_distribution = recipe_data["linux_distribution"]
             link = recipe_data["link"]
             recipe_path = self.download_artifact(link, md5sum)
+            template_dictionary = recipe_data.get("template_dictionary", [])
 
             try:
-                return ih.recipe_upload(recipe_name, recipe_path, linux_distribution)
+                return ih.recipe_upload(recipe_name, recipe_path, linux_distribution, template_dictionary)
             except requests.RequestException as exc:
                 if hasattr(exc, "response"):
                     LOGGER.warning("IMS Service Response is %s", exc.response.text)
@@ -417,21 +423,49 @@ class _ImsLoadArtifacts_v1_0_0:
         return all([ret_recipes, ret_images])
 
 
+def load_template(name):
+    """
+    Prevent malicious attackers from importing sensitive files in the container by
+    only allow jinja2 to read MANIFEST_FILE.
+    """
+    if name == MANIFEST_FILE:
+        with open(MANIFEST_FILE, encoding="utf-8") as inf:
+            return inf.read()
+    return None
+
+
 def load_artifacts():
     """
     Read a manifest.yaml file. If the object was not found, log it and return an error..
     """
-    with open(MANIFEST_FILE, 'rt', encoding='utf-8') as inf:
-        manifest_data = yaml.safe_load(inf)
 
+    manifest_file = MANIFEST_FILE
     try:
-        return {
-            "1.0.0": _ImsLoadArtifacts_v1_0_0()
-        }[manifest_data["version"]](manifest_data)
-    except KeyError:
-        raise ImsLoadArtifactsBaseException(
-            f"Cannot process manifest.yaml due to unsupported or missing manifest version {manifest_data}") \
-            from ValueError
+        if os.path.isfile(TEMPLATE_DICTIONARY):
+            LOGGER.info("Templating manifest.yaml")
+            template_loader = jinja2.FunctionLoader(load_template)
+            template_env = jinja2.Environment(loader=template_loader)
+            template = template_env.get_template(MANIFEST_FILE)
+            with open(TEMPLATE_DICTIONARY, encoding="utf-8") as td, \
+                    tempfile.NamedTemporaryFile("w", delete=False) as outf:
+                outf.write(template.render(**yaml.safe_load(td)))
+                manifest_file = outf.name
+                outf.close()
+
+        with open(manifest_file, 'rt', encoding='utf-8') as inf:
+            manifest_data = yaml.safe_load(inf)
+
+        try:
+            return {
+                "1.0.0": _ImsLoadArtifacts_v1_0_0()
+            }[manifest_data["version"]](manifest_data)
+        except KeyError:
+            raise ImsLoadArtifactsBaseException(
+                f"Cannot process manifest.yaml due to unsupported or missing manifest version {manifest_data}") \
+                from ValueError
+
+    except yaml.YAMLError as exc:
+        raise ImsLoadArtifactsBaseException("Cannot loading manifest.yaml.", exc=exc) from yaml.YAMLError
 
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ ims-python-helper
 requests
 pyyaml
 boto3
+jinja2

--- a/runUnitTests.sh
+++ b/runUnitTests.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# MIT License
+#
+# (C) Copyright 2018-2019, 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+DOCKER_NAME=ims-load-artifacts
+VERSION=testing
+
+docker build --target testing -t ${DOCKER_NAME}-unittests:${VERSION} .

--- a/tests/test_load_artifacts.py
+++ b/tests/test_load_artifacts.py
@@ -1,4 +1,7 @@
-# Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -12,13 +15,11 @@
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-#
-# (MIT License)
 
 """
 Unit tests for ims_load_artifacts
@@ -139,10 +140,11 @@ class TestLoadArtifacts(testtools.TestCase):
 
         # method call 2, to upload the recipe to S3 and IMS
         self.assertEqual(ih_mock.method_calls[1][0], "().recipe_upload")
-        self.assertEqual(len(ih_mock.method_calls[1][1]), 3)
+        self.assertEqual(len(ih_mock.method_calls[1][1]), 4)
         self.assertEqual(ih_mock.method_calls[1][1][0], "shasta_barebones_recipe-1.2.4")
         self.assertEqual(ih_mock.method_calls[1][1][1], "/tmp/cray-sles15sp1-barebones-1.2.4.tgz")
         self.assertEqual(ih_mock.method_calls[1][1][2], "sles15")
+        self.assertEqual(ih_mock.method_calls[1][1][3], [])
 
         # method call 3, to validate the md5 of the cray-sles15sp1-barebones-1.2.4.sqshfs
         self.assertEqual(ih_mock.method_calls[2][0], "_md5")


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

This PR updates ims-load-artifacts to be able to add recipes to IMS that contain template-dictionaries. 

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-7676](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7676)
* [ ] Merge after ims-python-helper changes (https://github.com/Cray-HPE/ims-python-helper/pull/4)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `mug`

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

Created a test recipe helm chart based on the updated cray-product-install-chart and ims-load-artifacts container. Installed this test recipe helm chart on mug. Saw that the recipe was added to IMS as expected, including that all templating during the helm install occurred as expected. Verified that building the recipe using IMS templated the recipe as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? If not, why? No
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
- [ ] Do not merge until CSMv2.5 code is able to be merged
