### PR TITLE
CASMTRIAGE-3756 - enhance error checking and log messages to help with file permission issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMTRIAGE-3756 - added file permission checking and better logging.
+- CASMCMS-7970 - ims update cray.dev.com addresses
 
 ## [1.4.0] - 2022-06-30
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,7 @@ RUN apk add --upgrade --no-cache apk-tools &&  \
         python3 && \
 	apk -U upgrade --no-cache && \
     pip3 install --upgrade pip \
-        --no-cache-dir \
-        --index-url https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple && \
+        --no-cache-dir && \
     pip3 install --no-cache-dir -r requirements.txt
 
 # The testing container

--- a/ims_load_artifacts/load_artifacts.py
+++ b/ims_load_artifacts/load_artifacts.py
@@ -95,6 +95,12 @@ class ImsLoadArtifactsFileNotFoundException(ImsLoadArtifactsBaseException):
     """
 
 
+class ImsLoadArtifactsPermissionException(ImsLoadArtifactsBaseException):
+    """
+    ImsLoadArtifacts Incorrect Permissions Exception
+    """
+
+
 def wait_for_istio():
     """
     Loop until we are successfully able to call the IMS ready endpoint.
@@ -218,12 +224,24 @@ class _ImsLoadArtifacts_v1_0_0:
             Handle local artifacts that have been baked into the
             ims-load-artifacts container.
             """
-            if not os.path.isfile(link["path"]):
+            filename = link["path"]
+            if not os.path.isfile(filename):
                 raise ImsLoadArtifactsFileNotFoundException(
-                    f"Failed to find artifact {link['path']} in given local container path. "
+                    f"Failed to find artifact {filename} in given local container path. "
                     "Please contact your service person to notify HPE of this error."
                 )
-            return link["path"]
+            if not os.access(filename, os.R_OK):
+                # log file permissions and ownership
+                st = os.stat(filename)
+                LOGGER.info("Accessing local file: %s", filename)
+                LOGGER.info("  File permissions: %s", oct(st.st_mode))
+                LOGGER.info("  File ownership: %d,%d", st.st_uid, st.st_gid)
+                LOGGER.info("  Current userid:grpid - %d:%d", os.getuid(), os.getgid())
+                raise ImsLoadArtifactsPermissionException(
+                    f"Failed to access artifact {filename} due to permission issues."
+                )
+
+            return filename
 
         try:
             local_filename = {
@@ -233,7 +251,10 @@ class _ImsLoadArtifacts_v1_0_0:
 
             if md5sum:
                 LOGGER.info("Verifying md5sum of the downloaded file.")
-                if md5sum != ImsHelper._md5(local_filename):  # pylint: disable=protected-access
+                lf_md5sum = ImsHelper._md5(local_filename)  # pylint: disable=protected-access
+                if md5sum != lf_md5sum:
+                    LOGGER.info("  Input md5    :%s", md5sum)
+                    LOGGER.info("  Download md5 :%s", lf_md5sum)
                     raise ImsLoadArtifactsDownloadException("The calculated md5sum does not match the expected value.")
                 LOGGER.info("Successfully verified the md5sum of the downloaded file.")
             else:
@@ -309,7 +330,7 @@ class _ImsLoadArtifacts_v1_0_0:
 
     def download_image_artifact(self, artifact_data):
         """ Helper function to download image artifact """
-
+        LOGGER.debug('Artifact Data: "%s" ', artifact_data)
         md5 = artifact_data["md5"]
         link = artifact_data["link"]
         mime_type = artifact_data["type"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # Only use Cray-procured packages
---index-url https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple
 --extra-index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
 --trusted-host artifactory.algol60.net
 -c constraints.txt


### PR DESCRIPTION
## Summary and Scope

Added more detailed logging messages and some more error checking to help with diagnosing another problem like this if it should come up.  No functional changes to the code.

## Issues and Related PRs
* Resolves [CASMTRIAGE-3756](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3756)
* Change will also be needed in the repo `image-recipes`

## Testing
### Tested on:
  * `surtur`

### Test description:

I uploaded new versions of the images and helm charts, then used helm/loftsman to uninstall/re-install the package.  This is not a running service, it just kicks off an import job that completes and exits.  After it completed the data import I verified it was correctly present in IMS and was able to be accessed for the barebones image boot test.  The boot test still failed, but that was due to BOA not having been updated for the new capmc API.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? N - not applicable
- Was upgrade tested? If not, why? N - not a running service
- Was downgrade tested? If not, why? N - not a running service
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations
This is a very low risk change as it only adds checking and logging.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

