### PR TITLE
CASMCMS-8272 - fix pylint issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2022-10-05
+### Changed
+- CASMCMS-8272 - add timeout to request due to pylint failure.
+
 ## [1.6.0] - 2022-08-02
 ### Changed
 - CASMCMS-7970 - update to new version of ims-python-helper.

--- a/ims_load_artifacts/load_artifacts.py
+++ b/ims_load_artifacts/load_artifacts.py
@@ -110,7 +110,7 @@ def wait_for_istio():
     while True:
         try:
             LOGGER.debug("Calling ims ready endpoint")
-            r = requests.get(ims_ready_endpoint)
+            r = requests.get(ims_ready_endpoint, timeout=10)
             if r.ok:
                 LOGGER.info("Successfully talked to IMS Ready endpoint.")
                 break


### PR DESCRIPTION
## Summary and Scope

I linting issue broke the automatic builds. The code is calling 'requests.get' and the linter wants a timeout specified for the http request. This is just in an infinite loop waiting for the ims service to be available, so I added a 10 sec timeout to the call. Instead of waiting forever for the http request, it my spin through the loop a few times now.

## Issues and Related PRs
* Resolves [CASMCMS-8272](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8272)

## Testing
### Tested on:
  * Local development environment

### Test description:

This is just a linting change - the update is minor and will not impact running code in mode cases so not tested on a machine.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk - just adding an http timeout in an infinite loop while it is waiting for the ims service to be available.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

