### PR TITLE
CASMINST-5509: Backport of CASMTRIAGE-3756

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,7 @@ RUN apk add --upgrade --no-cache apk-tools &&  \
         python3 && \
 	apk -U upgrade --no-cache && \
     pip3 install --upgrade pip \
-        --no-cache-dir \
-        --index-url https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple && \
+        --no-cache-dir && \
     pip3 install --no-cache-dir -r requirements.txt
 
 # The testing container

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # Only use Cray-procured packages
---index-url https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple
 --extra-index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
 --trusted-host artifactory.algol60.net
 -c constraints.txt


### PR DESCRIPTION
## Summary and Scope

This is a csm-1.2 backport of: https://github.com/Cray-HPE/ims-load-artifacts/pull/19

The root cause of CASMTRIAGE-3756 was a change in our build environment. The fix was only made to csm-1.3, but we are now seeing it in 1.2.2. This PR backports the fix to our csm-1.2 branch, to correct the issue.

Once this PR merges, it needs to be tagged and the stable artifact build needs to complete BEFORE the following PR should be merged: https://github.com/Cray-HPE/image-recipes/pull/33

## Issues and Related PRs

* [CASMTRIAGE-3756](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3756)
* https://github.com/Cray-HPE/ims-load-artifacts/pull/19
* https://github.com/Cray-HPE/image-recipes/pull/25
* https://github.com/Cray-HPE/image-recipes/pull/33

## Testing

The change being made is independent of the CSM version, so the testing from the previous PR should still be applicable.

## Risks and Mitigations

Without this fix, the barebones image build fails during installs.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
