### PR TITLE
CASM-3506: Add IUF support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add support for IUF `ims_upload` operation.
 
 ## [1.6.2] - 2022-12-02
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ FROM base as application
 RUN mkdir -p /ims_load_artifacts /results && \
   chown -R "nobody:nobody" /ims_load_artifacts /results
 
+ENV PYTHONPATH="/"
 USER nobody
 COPY ims_load_artifacts /ims_load_artifacts
 ENTRYPOINT ["/ims_load_artifacts/load_artifacts.py"]

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,7 +4,7 @@ certifi==2019.11.28
 chardet==3.0.4
 docutils==0.14
 idna==2.8
-ims-python-helper>=2.9.0
+ims-python-helper==2.10.0
 jmespath==0.9.4
 oauthlib==2.1.0
 python-dateutil==2.8.1

--- a/ims_load_artifacts/iuf.py
+++ b/ims_load_artifacts/iuf.py
@@ -1,0 +1,300 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Support for loading artifacts in IMS through the IUF
+"""
+from copy import deepcopy
+import logging
+import os
+from typing import Any, Iterable, Optional
+
+import yaml
+
+from ims_load_artifacts.loaders import ImsLoadArtifacts_v1_0_0
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_val_by_path(dict_val: dict, dotted_path: str, default_value: Optional = None) -> Any:
+    """Get a value from a dictionary based on a dotted path.
+
+    For example, if `dict_val` is as follows:
+
+    dict_val = {
+        'foo': {
+            'bar': 'baz'
+        }
+    }
+
+    Then get_val_by_path(dict_val, 'foo.bar') would return 'baz', and something
+    like get_val_by_path(dict_val, 'no.such.keys') would return None.
+
+    Args:
+        dict_val: The dictionary in which to search for the dotted path.
+        dotted_path: The dotted path to look for in the dictionary. The
+            dot character, '.', separates the keys to use when traversing a
+            nested dictionary.
+        default_value: The default value to return when the given dotted path
+            does not exist in the dict_val.
+
+    Returns:
+        The value that exists at the dotted path or `default_value` if no such
+        path exists in `dict_val`.
+    """
+    current_val = dict_val
+    for key in dotted_path.split('.'):
+        if current_val and key in current_val:
+            current_val = current_val[key]
+        else:
+            return default_value
+    return current_val
+
+
+def process_iuf_manifest(iuf_manifest: dict, distribution_root: str) -> dict:
+    """Transform IUF manifest content to manifest.yaml schema expected by ImsLoadArtifacts.
+
+    Args:
+        iuf_manifest: parsed content from the IUF product manifest
+        distribution_root: the path to the IUF product release distribution
+            mounted inside the container
+
+    Returns:
+        a dict with the same schema as a manifest.yaml file in a "legacy"
+        ims-load-artifacts Docker image. See README.md for details.
+    """
+    content_dir_manifests = {}
+    content_dirs = get_val_by_path(iuf_manifest, 'content.ims.content_dirs')
+    if content_dirs:
+        content_dir_manifests = process_content_dirs(content_dirs, distribution_root)
+
+    recipes = get_val_by_path(iuf_manifest, 'content.ims.recipes', [])
+    images = get_val_by_path(iuf_manifest, 'content.ims.images', [])
+    return merge_manifests(content_dir_manifests, process_enumerated_manifest(recipes, images, distribution_root))
+
+
+def process_enumerated_manifest(
+        recipes: Iterable[dict],
+        images: Iterable[dict],
+        distribution_root: str
+) -> dict:
+    """Transform an IUF manifest with enumerated images and recipes into a load-ims-artifacts manifest.
+
+    Args:
+        recipes: a list of recipes defined in the IUF product manifest
+        images: a list of images defined in the IUF product manifest
+        distribution_root: the path to the IUF product release distribution
+            mounted inside the container
+
+    Returns:
+        a dict with the same schema as a manifest.yaml file in a "legacy"
+        ims-load-artifacts Docker image. See README.md for details.
+    """
+    processed_manifest = {
+        'version': '1.0.0',  # Create a manifest compatible with the _ImsLoadArtifacts_v1_0_0 helper
+    }
+    processed_recipes = {}
+    for recipe in recipes:
+        recipe_path = recipe['path']
+        recipe_name = recipe.get('name')
+        if not recipe_name:
+            recipe_basename = os.path.basename(recipe_path)
+            if recipe_basename.endswith('.tar.gz'):
+                recipe_name = recipe_basename.removesuffix('.tar.gz')
+            else:
+                recipe_name, _ = os.path.splitext(recipe_basename)
+
+        built_recipe = {
+            key: recipe.get(key) for key in ['linux_distribution', 'recipe_type', 'template_dictionary']
+            if recipe.get(key) is not None
+        }
+        built_recipe.update({
+            'link': {
+                'type': 'file',
+                'path': os.path.join(distribution_root, recipe['path'])
+            },
+            'md5': recipe.get('md5sum', ''),
+        })
+        if recipe_name in processed_recipes:
+            LOGGER.warning('Recipe "%s" is duplicated in the IUF product manifest; '
+                           'only the last instance in the IUF product manifest will be imported.', recipe_name)
+        processed_recipes[recipe_name] = built_recipe
+    processed_manifest['recipes'] = processed_recipes
+
+    artifact_key_to_type = {
+        'rootfs': 'application/vnd.cray.image.rootfs.squashfs',
+        'kernel': 'application/vnd.cray.image.kernel',
+        'initrd': 'application/vnd.cray.image.initrd',
+    }
+
+    processed_images = {}
+    for image in images:
+        artifact_records = []
+        for artifact_key, artifact_type in artifact_key_to_type.items():
+            if artifact_key in image:
+                artifact = image[artifact_key]
+                artifact_records.append({
+                    'link': {
+                        'path': os.path.join(distribution_root, image['path'], artifact['path']),
+                        'type': 'file'
+                    },
+                    'type': artifact_type,
+                    'md5': artifact.get('md5sum', ''),
+                })
+
+        if artifact_records:
+            image_name = image.get('name', os.path.basename(image['path']))
+            if image_name in processed_images:
+                LOGGER.warning('Image "%s" is duplicated in the IUF product manifest;'
+                               'only the last instance in the IUF product manifest will be imported.', image_name)
+            processed_images[image_name] = {
+                'artifacts': artifact_records
+            }
+    processed_manifest['images'] = processed_images
+
+    return processed_manifest
+
+
+def process_content_dirs(content_dir_paths: Iterable[str], distribution_root: str) -> dict:
+    """Process the content_dirs provided in the IUF manifest into a single load-ims-artifacts manifest
+
+    Args:
+        content_dir_paths: paths to content directories enumerated in the IUF manifest.
+            Each content directory contains some IMS artifacts and a "legacy"
+            manifest.yaml file described in README.md.
+        distribution_root: the path to the IUF product release distribution
+            mounted inside the container
+
+    Returns:
+        a dict with the same schema as a manifest.yaml file in a "legacy"
+        ims-load-artifacts Docker image which combines the content from
+        all the enumerated content directories' manifest.yaml files.
+        See README.md for details.
+    """
+    content_dir_manifests = []
+    for content_dir_path in content_dir_paths:
+        full_content_dir_path = os.path.join(distribution_root, content_dir_path)
+        content_dir_manifest_path = os.path.join(full_content_dir_path, 'manifest.yaml')
+        try:
+            with open(content_dir_manifest_path, encoding='utf-8') as content_dir_manifest:
+                current_manifest = yaml.safe_load(content_dir_manifest)
+                content_dir_manifests.append(
+                    process_content_dir_manifest(
+                        current_manifest,
+                        full_content_dir_path
+                    )
+                )
+
+        except OSError as err:
+            LOGGER.warning('Could not open IMS content manifest %s; skipping', err)
+        except yaml.YAMLError as err:
+            LOGGER.warning('Could not parse manifest YAML from content directory %s: %s',
+                           content_dir_path, err)
+
+    return merge_manifests(*content_dir_manifests)
+
+
+def process_content_dir_manifest(content_dir_manifest: dict, content_dir_path: str) -> dict:
+    """Change artifact paths in content directories so their paths are correct
+
+    This is needed since the manifest.yaml files from ims-load-artifacts images
+    usually point to artifacts directly in the filesystem root. This function
+    rewrites the file paths such that the filesystem root is interpreted as the
+    content directory path, i.e. the root directory if the process chrooted
+    into the content directory.
+
+    Args:
+        content_dir_manifest: a parsed manifest.yaml from a content directory
+        content_dir_path: the path to the content directory containing the file
+            which contains the raw content_dir_manifest content.
+    """
+    def fix_path(old_path):
+        return os.path.join(content_dir_path, old_path.strip(os.path.sep))
+
+    new_manifest = deepcopy(content_dir_manifest)
+    for recipe_name in new_manifest.get('recipes', {}).keys():
+        old_path = new_manifest['recipes'][recipe_name]['link']['path']
+        new_manifest['recipes'][recipe_name]['link']['path'] = fix_path(old_path)
+
+    for image_name in new_manifest.get('images', {}).keys():
+        for image_artifact in new_manifest['images'][image_name]['artifacts']:
+            old_path = image_artifact['link']['path']
+            image_artifact['link']['path'] = fix_path(old_path)
+
+    return new_manifest
+
+
+def merge_manifests(*manifests: dict) -> dict:
+    """Merge multiple load-ims-artifacts manifests into one single manifest.
+
+    Note that this function does not support merging content directory manifests
+    which have duplicate image or recipe names. Image and recipe manifest contents
+    will be overwritten arbitrarily and a warning will be logged.
+
+    Args:
+        manifests: individual manifests constructed from parsed manifest.yaml
+            files from each content directory and from the IUF product manifest.
+
+    Returns:
+        the content directory manifests merged into a single manifest.
+    """
+    merged_manifest = {
+        'version': '1.0.0',
+    }
+
+    merged_recipes = {}
+    merged_images = {}
+    for manifest in manifests:
+        for recipe_name, recipe_contents in manifest.get('recipes', {}).items():
+            if recipe_name in merged_recipes:
+                LOGGER.warning('Duplicate recipe %s detected', recipe_name)
+            merged_recipes[recipe_name] = recipe_contents
+        for image_name, image_contents in manifest.get('images', {}).items():
+            if image_name in merged_images:
+                LOGGER.warning('Duplicate image %s detected', image_name)
+            merged_images[image_name] = image_contents
+
+    if merged_recipes:
+        merged_manifest['recipes'] = merged_recipes
+
+    if merged_images:
+        merged_manifest['images'] = merged_images
+
+    return merged_manifest
+
+
+def iuf_load_artifacts(iuf_distribution_root: str, iuf_manifest_path: str) -> bool:
+    """Main entrypoint for IUF artifact loader."""
+    with open(iuf_manifest_path, encoding='utf-8') as iuf_manifest:
+        try:
+            manifest_input_data = process_iuf_manifest(
+                yaml.safe_load(iuf_manifest),
+                iuf_distribution_root
+            )
+        except yaml.YAMLError as err:
+            LOGGER.error("Could not load IUF product manifest: %s", err)
+            return False
+
+    artifact_loader = ImsLoadArtifacts_v1_0_0()
+    return artifact_loader(manifest_input_data)

--- a/ims_load_artifacts/load_artifacts.py
+++ b/ims_load_artifacts/load_artifacts.py
@@ -33,72 +33,23 @@ import os
 import sys
 import tempfile
 import time
-from string import Template
+from functools import partial
 
-import botocore.exceptions
 import jinja2
 import requests
 import urllib3
 import yaml
-from ims_python_helper import ImsHelper
-from requests.adapters import HTTPAdapter
-from urllib3.util import Retry
+
+import ims_load_artifacts.loaders
+from ims_load_artifacts.iuf import iuf_load_artifacts
+from ims_load_artifacts.loaders import IMS_URL, ImsLoadArtifactsBaseException, ImsLoadArtifacts_v1_0_0
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-LOGGER = logging.getLogger(__name__)
-
 MANIFEST_FILE = os.environ.get("MANIFEST_FILE", "/manifest.yaml")
 TEMPLATE_DICTIONARY = os.environ.get("TEMPLATE_DICTIONARY", "/mnt/image-recipe-import/template_dictionary")
-IMS_URL = os.environ.get('IMS_URL', 'http://cray-ims').strip("/")
-S3_IMS_BUCKET = os.environ.get('S3_IMS_BUCKET', "ims")
-S3_BOOT_IMAGES_BUCKET = os.getenv('S3_BOOT_IMAGES_BUCKET', 'boot-images')
-DOWNLOAD_ROOT = os.getenv('DOWNLOAD_PATH', '/tmp')
 
-BOS_URL = os.environ.get('BOS_URL', 'http://cray-bos').strip("/")
-BOS_SESSION_ENDPOINT = os.environ.get('BOS_SESSION_ENDPOINT', 'v1/sessiontemplate').lstrip("/")
-BOS_KERNEL_PARAMETERS = os.environ.get('BOS_KERNEL_PARAMETERS',
-                                       "console=ttyS0,115200 bad_page=panic crashkernel=340M hugepagelist=2m-2g "
-                                       "intel_iommu=off intel_pstate=disable iommu=pt ip=dhcp "
-                                       "numa_interleave_omit=headless numa_zonelist_order=node oops=panic "
-                                       "pageblock_order=14 pcie_ports=native printk.synchronous=y rd.neednet=1 "
-                                       "rd.retry=10 rd.shell turbo_boost_limit=999 "
-                                       "spire_join_token=${SPIRE_JOIN_TOKEN}")
-BOS_ROOTFS_PROVIDER = os.environ.get('BOS_ROOTFS_PROVIDER', 'cpss3')
-BOS_ROOTFS_PROVIDER_PASSTHROUGH = os.environ.get(
-    'BOS_ROOTFS_PROVIDER_PASSTHROUGH', 'dvs:api-gw-service-nmn.local:300:nmn0')
-BOS_CFS_CONFIGURATION = os.environ.get('BOS_CFS_CONFIGURATION', '')
-BOS_ENABLE_CFS = \
-    'True' if os.environ.get('BOS_ENABLE_CFS', 'False').lower in ['true', 'on', 'yes', 't', '1'] else 'False'
-
-S3_ENDPOINT = None
-S3_SECRET_KEY = None
-S3_ACCESS_KEY = None
-S3_SSL_VERIFY = None
-
-
-class ImsLoadArtifactsBaseException(Exception):
-    """
-    Toplevel ImsLoadArtifacts Exception
-    """
-
-
-class ImsLoadArtifactsDownloadException(ImsLoadArtifactsBaseException):
-    """
-    ImsLoadArtifacts Download Exception
-    """
-
-
-class ImsLoadArtifactsFileNotFoundException(ImsLoadArtifactsBaseException):
-    """
-    ImsLoadArtifacts File Not Found Exception
-    """
-
-
-class ImsLoadArtifactsPermissionException(ImsLoadArtifactsBaseException):
-    """
-    ImsLoadArtifacts Incorrect Permissions Exception
-    """
+LOGGER = logging.getLogger(__name__)
 
 
 def wait_for_istio():
@@ -119,330 +70,6 @@ def wait_for_istio():
             LOGGER.warning(exc)
         LOGGER.info("Trying again in 2 seconds")
         time.sleep(2)
-
-
-class _ImsLoadArtifacts_v1_0_0:
-    """
-    Load Artifacts Handler for 1.0.0 versioned manifest files
-    """
-
-    BOS_SESSION_TEMPLATE = \
-        """
-        boot_sets:
-          compute:
-            boot_ordinal: 2
-            etag: ${ims_etag}
-            kernel_parameters: ${bos_kernel_parameters}
-            network: nmn
-            node_roles_groups:
-            - Compute
-            path: ${ims_manifest_path}
-            rootfs_provider: ${bos_rootfs_provider}
-            rootfs_provider_passthrough: ${bos_rootfs_provider_passthrough}
-            type: s3
-        cfs:
-          configuration: ${bos_cfs_configuration}
-        enable_cfs: ${bos_enable_cfs}
-        name: ${ims_image_name}
-        """
-
-    def __init__(self):
-        self.session = requests.session()
-        self.retries = Retry(total=10, backoff_factor=2, status_forcelist=[502, 503, 504])
-        self.session.mount("http://", HTTPAdapter(max_retries=self.retries))
-
-    def create_bos_session_template(self, ims_etag, ims_manifest_path, ims_image_id):
-        """
-        Generate a BOS Session template for the IMS Image
-        """
-        try:
-            bos_session_template = Template(self.BOS_SESSION_TEMPLATE).substitute({
-                "ims_etag": ims_etag,
-                "ims_manifest_path": ims_manifest_path,
-                "ims_image_name": f'"IMS Id: {ims_image_id}"',
-                'bos_kernel_parameters': BOS_KERNEL_PARAMETERS,
-                'bos_rootfs_provider': BOS_ROOTFS_PROVIDER,
-                'bos_rootfs_provider_passthrough': BOS_ROOTFS_PROVIDER_PASSTHROUGH,
-                'bos_cfs_configuration': BOS_CFS_CONFIGURATION,
-                'bos_enable_cfs': BOS_ENABLE_CFS,
-            })
-            LOGGER.debug(bos_session_template)
-            body = yaml.safe_load(bos_session_template)
-            if not isinstance(body, dict):
-                LOGGER.error("Session Template must be formatted as a dictionary.")
-                return False
-
-            # When loading a dictionary value that is an empty string, yaml will convert the empty string to None.
-            # >> > a = "{ a: { b: "" } }"
-            # >> > yaml.safe_load(a)
-            # {'a': {'b': None}}
-            # This can cause BOS to throw an error. Fix up possible None values.
-
-            body["boot_sets"]["compute"]["kernel_parameters"] = \
-                '' if not body["boot_sets"]["compute"]["kernel_parameters"] \
-                else body["boot_sets"]["compute"]["kernel_parameters"]
-            body["boot_sets"]["compute"]["rootfs_provider"] = \
-                '' if not body["boot_sets"]["compute"]["rootfs_provider"] \
-                else body["boot_sets"]["compute"]["rootfs_provider"]
-            body["boot_sets"]["compute"]["rootfs_provider_passthrough"] = \
-                '' if not body["boot_sets"]["compute"]["rootfs_provider_passthrough"] \
-                else body["boot_sets"]["compute"]["rootfs_provider_passthrough"]
-            body["cfs"]["configuration"] = \
-                '' if not body["cfs"]["configuration"] \
-                else body["cfs"]["configuration"]
-
-        except yaml.YAMLError as exc:
-            LOGGER.error("BOS Session Template was not proper YAML: %s", exc)
-            return False
-        try:
-            resp = self.session.post('/'.join([BOS_URL, BOS_SESSION_ENDPOINT]), json=body)
-            resp.raise_for_status()
-        except requests.RequestException as err:
-            LOGGER.error("Problem contacting the Boot Orchestration Service (BOS): %s", err)
-            return False
-        return True
-
-    def download_artifact(self, link, md5sum):
-        """ download and verify artifact using link reference """
-
-        def _download_http_artifact():
-            """
-            Handle download of http artifact
-            """
-
-            local_filename = os.path.abspath(os.path.join(DOWNLOAD_ROOT, link["path"].split('/')[-1]))
-            with self.session.get(link["path"], stream=True) as r:
-                r.raise_for_status()
-                one_megabyte = 1024 * 1024
-                with open(local_filename, 'wb') as f:
-                    for chunk in r.iter_content(chunk_size=one_megabyte):
-                        f.write(chunk)
-            return local_filename
-
-        def _download_file_artifact():
-            """
-            Handle local artifacts that have been baked into the
-            ims-load-artifacts container.
-            """
-            filename = link["path"]
-            if not os.path.isfile(filename):
-                raise ImsLoadArtifactsFileNotFoundException(
-                    f"Failed to find artifact {filename} in given local container path. "
-                    "Please contact your service person to notify HPE of this error."
-                )
-            if not os.access(filename, os.R_OK):
-                # log file permissions and ownership
-                st = os.stat(filename)
-                LOGGER.info("Accessing local file: %s", filename)
-                LOGGER.info("  File permissions: %s", oct(st.st_mode))
-                LOGGER.info("  File ownership: %d,%d", st.st_uid, st.st_gid)
-                LOGGER.info("  Current userid:grpid - %d:%d", os.getuid(), os.getgid())
-                raise ImsLoadArtifactsPermissionException(
-                    f"Failed to access artifact {filename} due to permission issues."
-                )
-
-            return filename
-
-        try:
-            local_filename = {
-                "http": _download_http_artifact,
-                "file": _download_file_artifact,
-            }[link["type"]]()
-
-            if md5sum:
-                LOGGER.info("Verifying md5sum of the downloaded file.")
-                lf_md5sum = ImsHelper._md5(local_filename)  # pylint: disable=protected-access
-                if md5sum != lf_md5sum:
-                    LOGGER.info("  Input md5    :%s", md5sum)
-                    LOGGER.info("  Download md5 :%s", lf_md5sum)
-                    raise ImsLoadArtifactsDownloadException("The calculated md5sum does not match the expected value.")
-                LOGGER.info("Successfully verified the md5sum of the downloaded file.")
-            else:
-                LOGGER.info("Not verifying md5sum of the downloaded file.")
-
-            return local_filename
-        except KeyError:
-            raise ImsLoadArtifactsDownloadException(
-                f"Cannot download artifact due to unsupported or missing link type. {link}") from ValueError
-
-    def load_recipe(self, ih, recipe_name, recipe_data):
-        """ call IMS Helper to load recipe into IMS and S3 """
-
-        ret_value = False
-        try:
-            md5sum = recipe_data["md5"]
-            linux_distribution = recipe_data["linux_distribution"]
-            link = recipe_data["link"]
-            recipe_path = self.download_artifact(link, md5sum)
-            template_dictionary = recipe_data.get("template_dictionary", [])
-
-            try:
-                return ih.recipe_upload(recipe_name, recipe_path, linux_distribution, template_dictionary)
-            except requests.RequestException as exc:
-                if hasattr(exc, "response"):
-                    LOGGER.warning("IMS Service Response is %s", exc.response.text)
-                else:
-                    LOGGER.warning(exc)
-            except (botocore.exceptions.BotoCoreError,
-                    ImsLoadArtifactsDownloadException,
-                    ImsLoadArtifactsFileNotFoundException) as exc:
-                LOGGER.warning(exc)
-                ret_value = False
-
-        except (requests.RequestException, ImsLoadArtifactsDownloadException,
-                ImsLoadArtifactsFileNotFoundException) as exc:
-            LOGGER.warning("Error downloading recipe %s. %s", recipe_name, str(exc))
-            ret_value = False
-        except ValueError as exc:
-            LOGGER.warning("Malformed recipe %s in manifest. Missing recipe value. %s", recipe_name, str(exc))
-            ret_value = False
-
-        return ret_value
-
-    def load_recipes(self, manifest_data):
-        """ Process IMS recipes listed in the manifest file. """
-
-        ret_value = True
-        recipe_results = {'recipes': {}}
-
-        ih = ImsHelper(
-            ims_url=IMS_URL,
-            session=self.session,
-            s3_endpoint=S3_ENDPOINT,
-            s3_secret_key=S3_SECRET_KEY,
-            s3_access_key=S3_ACCESS_KEY,
-            s3_ssl_verify=S3_SSL_VERIFY,
-            s3_bucket=S3_IMS_BUCKET
-        )
-
-        if "recipes" in manifest_data:
-            for recipe_name, recipe_data in manifest_data["recipes"].items():
-                recipe_result = self.load_recipe(ih, recipe_name, recipe_data)
-                if recipe_result:
-                    recipe_results['recipes'][recipe_name] = {'id': recipe_result['id']}
-                else:
-                    ret_value = False
-
-        if ret_value:
-            return recipe_results
-
-        return ret_value
-
-    def download_image_artifact(self, artifact_data):
-        """ Helper function to download image artifact """
-        LOGGER.debug('Artifact Data: "%s" ', artifact_data)
-        md5 = artifact_data["md5"]
-        link = artifact_data["link"]
-        mime_type = artifact_data["type"]
-        artifact_path = self.download_artifact(link, md5)
-        return mime_type, artifact_path
-
-    def load_image(self, ih, image_name, image_data):
-        """ call IMS Helper to load image into IMS and S3 """
-        ret_value = False
-        try:
-            image_artifacts = {}
-            for artifact_data in image_data["artifacts"]:
-                mime_type, image_artifact = self.download_image_artifact(artifact_data)
-                image_artifacts[mime_type] = image_artifact
-
-            rootfs = [image_artifacts['application/vnd.cray.image.rootfs.squashfs']] \
-                if image_artifacts.get('application/vnd.cray.image.rootfs.squashfs') else None
-            kernel = [image_artifacts['application/vnd.cray.image.kernel']] \
-                if image_artifacts.get('application/vnd.cray.image.kernel') else None
-            initrd = [image_artifacts['application/vnd.cray.image.initrd']] \
-                if image_artifacts.get('application/vnd.cray.image.initrd') else None
-            boot_parameters = [image_artifacts['application/vnd.cray.image.parameters.boot']] \
-                if image_artifacts.get('application/vnd.cray.image.parameters.boot') else None
-
-            ih_upload_kwargs = {
-                'image_name': image_name,
-                'rootfs': rootfs,
-                'kernel': kernel,
-                'initrd': initrd,
-                'boot_parameters': boot_parameters
-            }
-
-            try:
-                result = ih.image_upload_artifacts(**ih_upload_kwargs)
-                if os.environ.get("CREATE_BOS_SESSION_TEMPLATE", "False").lower() in ['true', 'on', 'yes', 't', '1']:
-                    try:
-                        LOGGER.info('Creating BOS Session Temnplate for image "%s"', image_name)
-                        ims_etag = result["ims_image_record"]["link"]["etag"]
-                        ims_image_path = result["ims_image_record"]["link"]["path"]
-                        ims_image_id = result["ims_image_record"]["id"]
-                        self.create_bos_session_template(ims_etag, ims_image_path, ims_image_id)
-                    except KeyError as exc:
-                        LOGGER.error("Error creating BOS Session Template. IMS image result missing variable %s. %s",
-                                     exc, result)
-                return result
-            except requests.RequestException as exc:
-                if hasattr(exc, "response"):
-                    LOGGER.warning("IMS Service Response is %s", exc.response.text)
-                else:
-                    LOGGER.warning(exc)
-            except (botocore.exceptions.BotoCoreError,
-                    ImsLoadArtifactsDownloadException,
-                    ImsLoadArtifactsFileNotFoundException) as exc:
-                LOGGER.warning(exc)
-                ret_value = False
-
-        except (requests.RequestException, ImsLoadArtifactsDownloadException,
-                ImsLoadArtifactsFileNotFoundException) as exc:
-            LOGGER.warning("Error downloading image %s. %s", image_name, str(exc))
-            ret_value = False
-
-        except ValueError as exc:
-            LOGGER.warning("Malformed image %s in manifest. Missing image value. %s", image_name, str(exc))
-            ret_value = False
-
-        return ret_value
-
-    def load_images(self, manifest_data):
-        """ Process IMS images listed in the manifest file. """
-
-        ret_value = True
-        image_results = {'images': {}}
-
-        ih = ImsHelper(
-            ims_url=IMS_URL,
-            session=self.session,
-            s3_endpoint=S3_ENDPOINT,
-            s3_secret_key=S3_SECRET_KEY,
-            s3_access_key=S3_ACCESS_KEY,
-            s3_ssl_verify=S3_SSL_VERIFY,
-            s3_bucket=S3_BOOT_IMAGES_BUCKET
-        )
-
-        if "images" in manifest_data:
-            for image_name, image_data in manifest_data["images"].items():
-                image_result = self.load_image(ih, image_name, image_data)
-                if image_result:
-                    image_results['images'][image_name] = {
-                        'id': image_result['ims_image_record']['id']
-                    }
-                else:
-                    ret_value = False
-
-        if ret_value:
-            return image_results
-
-        return ret_value
-
-    def __call__(self, manifest_data):
-        """ Process IMS recipes and images listed in the manifest file. """
-        ret_recipes = self.load_recipes(manifest_data)
-        ret_images = self.load_images(manifest_data)
-
-        # If everything was successful, write out the results
-        if all([ret_recipes, ret_images]):
-            records = dict(ret_recipes, **ret_images)
-            LOGGER.info(yaml.dump(records))
-            with open('/results/records.yaml', 'wt', encoding='utf-8') as results_file:
-                yaml.dump(records, results_file)
-
-        # Return a boolean of if everything was successful
-        return all([ret_recipes, ret_images])
 
 
 def load_template(name):
@@ -479,7 +106,7 @@ def load_artifacts():
 
         try:
             return {
-                "1.0.0": _ImsLoadArtifacts_v1_0_0()
+                "1.0.0": ImsLoadArtifacts_v1_0_0()
             }[manifest_data["version"]](manifest_data)
         except KeyError:
             raise ImsLoadArtifactsBaseException(
@@ -490,18 +117,10 @@ def load_artifacts():
         raise ImsLoadArtifactsBaseException("Cannot loading manifest.yaml.", exc=exc) from yaml.YAMLError
 
 
-def main():
+def main() -> int:
     """
     Load artifacts from manifest.yaml into S3 and register with IMS.
     """
-
-    # pylint: disable=global-statement
-    global S3_ENDPOINT
-    global S3_SECRET_KEY
-    global S3_ACCESS_KEY
-    global S3_SSL_VERIFY
-
-    retValue = 0
 
     log_level = os.environ.get('LOG_LEVEL', 'WARN')
     logging.basicConfig(level=log_level)
@@ -515,24 +134,31 @@ def main():
         #   s3_endpoint: aHR0cDovL3Jndy5sb2NhbDo4MDgw
         #   secret_key: NDdHZUdPanhPNlhRc2RMUWxyb1k3WXhvMWNqb2NLMmoxQnBRb0o4NQ==
         #   ssl_validate: ZmFsc2U=
-        S3_ENDPOINT = os.environ['S3_ENDPOINT']
-        S3_SECRET_KEY = os.environ['SECRET_KEY']
-        S3_ACCESS_KEY = os.environ['ACCESS_KEY']
-        S3_SSL_VERIFY = os.environ['SSL_VALIDATE']
+        ims_load_artifacts.loaders.S3_ENDPOINT = os.environ['S3_ENDPOINT']
+        ims_load_artifacts.loaders.S3_SECRET_KEY = os.environ['SECRET_KEY']
+        ims_load_artifacts.loaders.S3_ACCESS_KEY = os.environ['ACCESS_KEY']
+        ims_load_artifacts.loaders.S3_SSL_VERIFY = os.environ['SSL_VALIDATE']
     except KeyError as key_error:
         LOGGER.error("Missing environment variable %s.", key_error)
         sys.exit(1)
 
-    wait_for_istio()
-
     try:
-        retValue = 0 if load_artifacts() else 1
+        is_in_iuf = bool(os.getenv('IUF'))
+        if is_in_iuf:
+            iuf_distribution_root = os.getenv('IUF_RELEASE_PATH', os.getcwd())
+            iuf_manifest_path = os.getenv('IUF_MANIFEST_PATH',
+                                          os.path.join(iuf_distribution_root, 'iuf-product-manifest.yaml'))
+            load_artifacts_fn = partial(iuf_load_artifacts, iuf_distribution_root, iuf_manifest_path)
+        else:
+            load_artifacts_fn = load_artifacts
+            wait_for_istio()
+        return int(not load_artifacts_fn())
     except FileNotFoundError as exc:
         LOGGER.error("Missing manifest file.", exc_info=exc)
     except ImsLoadArtifactsBaseException as exc:
         LOGGER.error(exc)
 
-    return retValue
+    return 1
 
 
 if __name__ == '__main__':

--- a/ims_load_artifacts/loaders.py
+++ b/ims_load_artifacts/loaders.py
@@ -1,0 +1,415 @@
+#
+# MIT License
+#
+# (C) Copyright 2018-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Common utilities for loading artifacts into IMS
+"""
+
+import logging
+import os
+from string import Template
+
+import botocore.exceptions
+from ims_python_helper import ImsHelper
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
+import yaml
+
+
+LOGGER = logging.getLogger(__name__)
+IMS_URL = os.environ.get('IMS_URL', 'http://cray-ims').strip("/")
+S3_IMS_BUCKET = os.environ.get('S3_IMS_BUCKET', "ims")
+S3_BOOT_IMAGES_BUCKET = os.getenv('S3_BOOT_IMAGES_BUCKET', 'boot-images')
+DOWNLOAD_ROOT = os.getenv('DOWNLOAD_PATH', '/tmp')
+BOS_URL = os.environ.get('BOS_URL', 'http://cray-bos').strip("/")
+BOS_SESSION_ENDPOINT = os.environ.get('BOS_SESSION_ENDPOINT', 'v1/sessiontemplate').lstrip("/")
+BOS_KERNEL_PARAMETERS = os.environ.get('BOS_KERNEL_PARAMETERS',
+                                       "console=ttyS0,115200 bad_page=panic crashkernel=340M hugepagelist=2m-2g "
+                                       "intel_iommu=off intel_pstate=disable iommu=pt ip=dhcp "
+                                       "numa_interleave_omit=headless numa_zonelist_order=node oops=panic "
+                                       "pageblock_order=14 pcie_ports=native printk.synchronous=y rd.neednet=1 "
+                                       "rd.retry=10 rd.shell turbo_boost_limit=999 "
+                                       "spire_join_token=${SPIRE_JOIN_TOKEN}")
+BOS_ROOTFS_PROVIDER = os.environ.get('BOS_ROOTFS_PROVIDER', 'cpss3')
+BOS_ROOTFS_PROVIDER_PASSTHROUGH = os.environ.get(
+    'BOS_ROOTFS_PROVIDER_PASSTHROUGH', 'dvs:api-gw-service-nmn.local:300:nmn0')
+BOS_CFS_CONFIGURATION = os.environ.get('BOS_CFS_CONFIGURATION', '')
+BOS_ENABLE_CFS = \
+    'True' if os.environ.get('BOS_ENABLE_CFS', 'False').lower in ['true', 'on', 'yes', 't', '1'] else 'False'
+
+S3_ENDPOINT = None
+S3_SECRET_KEY = None
+S3_ACCESS_KEY = None
+S3_SSL_VERIFY = None
+
+
+class ImsLoadArtifactsBaseException(Exception):
+    """
+    Toplevel ImsLoadArtifacts Exception
+    """
+
+
+class ImsLoadArtifactsDownloadException(ImsLoadArtifactsBaseException):
+    """
+    ImsLoadArtifacts Download Exception
+    """
+
+
+class ImsLoadArtifactsFileNotFoundException(ImsLoadArtifactsBaseException):
+    """
+    ImsLoadArtifacts File Not Found Exception
+    """
+
+
+class ImsLoadArtifactsPermissionException(ImsLoadArtifactsBaseException):
+    """
+    ImsLoadArtifacts Incorrect Permissions Exception
+    """
+
+
+class ImsLoadArtifacts_v1_0_0:
+    """
+    Load Artifacts Handler for 1.0.0 versioned manifest files
+    """
+
+    BOS_SESSION_TEMPLATE = \
+        """
+        boot_sets:
+          compute:
+            boot_ordinal: 2
+            etag: ${ims_etag}
+            kernel_parameters: ${bos_kernel_parameters}
+            network: nmn
+            node_roles_groups:
+            - Compute
+            path: ${ims_manifest_path}
+            rootfs_provider: ${bos_rootfs_provider}
+            rootfs_provider_passthrough: ${bos_rootfs_provider_passthrough}
+            type: s3
+        cfs:
+          configuration: ${bos_cfs_configuration}
+        enable_cfs: ${bos_enable_cfs}
+        name: ${ims_image_name}
+        """
+
+    def __init__(self):
+        self.session = requests.session()
+        auth_token = os.getenv('AUTH_TOKEN')
+        if auth_token:
+            self.session.headers['Authorization'] = 'Bearer ' + auth_token
+        self.retries = Retry(total=10, backoff_factor=2, status_forcelist=[502, 503, 504])
+        self.session.mount("http://", HTTPAdapter(max_retries=self.retries))
+
+    def create_bos_session_template(self, ims_etag, ims_manifest_path, ims_image_id):
+        """
+        Generate a BOS Session template for the IMS Image
+        """
+        try:
+            bos_session_template = Template(self.BOS_SESSION_TEMPLATE).substitute({
+                "ims_etag": ims_etag,
+                "ims_manifest_path": ims_manifest_path,
+                "ims_image_name": f'"IMS Id: {ims_image_id}"',
+                'bos_kernel_parameters': BOS_KERNEL_PARAMETERS,
+                'bos_rootfs_provider': BOS_ROOTFS_PROVIDER,
+                'bos_rootfs_provider_passthrough': BOS_ROOTFS_PROVIDER_PASSTHROUGH,
+                'bos_cfs_configuration': BOS_CFS_CONFIGURATION,
+                'bos_enable_cfs': BOS_ENABLE_CFS,
+            })
+            LOGGER.debug(bos_session_template)
+            body = yaml.safe_load(bos_session_template)
+            if not isinstance(body, dict):
+                LOGGER.error("Session Template must be formatted as a dictionary.")
+                return False
+
+            # When loading a dictionary value that is an empty string, yaml will convert the empty string to None.
+            # >> > a = "{ a: { b: "" } }"
+            # >> > yaml.safe_load(a)
+            # {'a': {'b': None}}
+            # This can cause BOS to throw an error. Fix up possible None values.
+
+            body["boot_sets"]["compute"]["kernel_parameters"] = \
+                '' if not body["boot_sets"]["compute"]["kernel_parameters"] \
+                else body["boot_sets"]["compute"]["kernel_parameters"]
+            body["boot_sets"]["compute"]["rootfs_provider"] = \
+                '' if not body["boot_sets"]["compute"]["rootfs_provider"] \
+                else body["boot_sets"]["compute"]["rootfs_provider"]
+            body["boot_sets"]["compute"]["rootfs_provider_passthrough"] = \
+                '' if not body["boot_sets"]["compute"]["rootfs_provider_passthrough"] \
+                else body["boot_sets"]["compute"]["rootfs_provider_passthrough"]
+            body["cfs"]["configuration"] = \
+                '' if not body["cfs"]["configuration"] \
+                else body["cfs"]["configuration"]
+
+        except yaml.YAMLError as exc:
+            LOGGER.error("BOS Session Template was not proper YAML: %s", exc)
+            return False
+        try:
+            resp = self.session.post('/'.join([BOS_URL, BOS_SESSION_ENDPOINT]), json=body)
+            resp.raise_for_status()
+        except requests.RequestException as err:
+            LOGGER.error("Problem contacting the Boot Orchestration Service (BOS): %s", err)
+            return False
+        return True
+
+    def download_artifact(self, link, md5sum):
+        """ download and verify artifact using link reference """
+
+        def _download_http_artifact():
+            """
+            Handle download of http artifact
+            """
+
+            local_filename = os.path.abspath(os.path.join(DOWNLOAD_ROOT, link["path"].split('/')[-1]))
+            with self.session.get(link["path"], stream=True) as r:
+                r.raise_for_status()
+                one_megabyte = 1024 * 1024
+                with open(local_filename, 'wb') as f:
+                    for chunk in r.iter_content(chunk_size=one_megabyte):
+                        f.write(chunk)
+            return local_filename
+
+        def _download_file_artifact():
+            """
+            Handle local artifacts that have been baked into the
+            ims-load-artifacts container.
+            """
+            filename = link["path"]
+            if not os.path.isfile(filename):
+                raise ImsLoadArtifactsFileNotFoundException(
+                    f"Failed to find artifact {filename} in given local container path. "
+                    "Please contact your service person to notify HPE of this error."
+                )
+            if not os.access(filename, os.R_OK):
+                # log file permissions and ownership
+                st = os.stat(filename)
+                LOGGER.info("Accessing local file: %s", filename)
+                LOGGER.info("  File permissions: %s", oct(st.st_mode))
+                LOGGER.info("  File ownership: %d,%d", st.st_uid, st.st_gid)
+                LOGGER.info("  Current userid:grpid - %d:%d", os.getuid(), os.getgid())
+                raise ImsLoadArtifactsPermissionException(
+                    f"Failed to access artifact {filename} due to permission issues."
+                )
+
+            return filename
+
+        try:
+            local_filename = {
+                "http": _download_http_artifact,
+                "file": _download_file_artifact,
+            }[link["type"]]()
+
+            if md5sum:
+                LOGGER.info("Verifying md5sum of the downloaded file.")
+                lf_md5sum = ImsHelper._md5(local_filename)  # pylint: disable=protected-access
+                if md5sum != lf_md5sum:
+                    LOGGER.info("  Input md5    :%s", md5sum)
+                    LOGGER.info("  Download md5 :%s", lf_md5sum)
+                    raise ImsLoadArtifactsDownloadException("The calculated md5sum does not match the expected value.")
+                LOGGER.info("Successfully verified the md5sum of the downloaded file.")
+            else:
+                LOGGER.info("Not verifying md5sum of the downloaded file.")
+
+            return local_filename
+        except KeyError:
+            raise ImsLoadArtifactsDownloadException(
+                f"Cannot download artifact due to unsupported or missing link type. {link}") from ValueError
+
+    def load_recipe(self, ih, recipe_name, recipe_data):
+        """ call IMS Helper to load recipe into IMS and S3 """
+
+        ret_value = False
+        try:
+            md5sum = recipe_data["md5"]
+            linux_distribution = recipe_data["linux_distribution"]
+            link = recipe_data["link"]
+            recipe_path = self.download_artifact(link, md5sum)
+            template_dictionary = recipe_data.get("template_dictionary", [])
+
+            try:
+                return ih.recipe_upload(recipe_name, recipe_path, linux_distribution, template_dictionary)
+            except requests.RequestException as exc:
+                if hasattr(exc, "response"):
+                    LOGGER.warning("IMS Service Response is %s", exc.response.text)
+                else:
+                    LOGGER.warning(exc)
+            except (botocore.exceptions.BotoCoreError,
+                    ImsLoadArtifactsDownloadException,
+                    ImsLoadArtifactsFileNotFoundException) as exc:
+                LOGGER.warning(exc)
+                ret_value = False
+
+        except (requests.RequestException, ImsLoadArtifactsDownloadException,
+                ImsLoadArtifactsFileNotFoundException) as exc:
+            LOGGER.warning("Error downloading recipe %s. %s", recipe_name, str(exc))
+            ret_value = False
+        except ValueError as exc:
+            LOGGER.warning("Malformed recipe %s in manifest. Missing recipe value. %s", recipe_name, str(exc))
+            ret_value = False
+
+        return ret_value
+
+    def load_recipes(self, manifest_data):
+        """ Process IMS recipes listed in the manifest file. """
+
+        ret_value = True
+        recipe_results = {'recipes': {}}
+
+        ih = ImsHelper(
+            ims_url=IMS_URL,
+            session=self.session,
+            s3_endpoint=S3_ENDPOINT,
+            s3_secret_key=S3_SECRET_KEY,
+            s3_access_key=S3_ACCESS_KEY,
+            s3_ssl_verify=S3_SSL_VERIFY,
+            s3_bucket=S3_IMS_BUCKET
+        )
+
+        if "recipes" in manifest_data:
+            for recipe_name, recipe_data in manifest_data["recipes"].items():
+                recipe_result = self.load_recipe(ih, recipe_name, recipe_data)
+                if recipe_result:
+                    recipe_results['recipes'][recipe_name] = {'id': recipe_result['id']}
+                else:
+                    ret_value = False
+
+        if ret_value:
+            return recipe_results
+
+        return ret_value
+
+    def download_image_artifact(self, artifact_data):
+        """ Helper function to download image artifact """
+        LOGGER.debug('Artifact Data: "%s" ', artifact_data)
+        md5 = artifact_data["md5"]
+        link = artifact_data["link"]
+        mime_type = artifact_data["type"]
+        artifact_path = self.download_artifact(link, md5)
+        return mime_type, artifact_path
+
+    def load_image(self, ih, image_name, image_data):
+        """ call IMS Helper to load image into IMS and S3 """
+        ret_value = False
+        try:
+            image_artifacts = {}
+            for artifact_data in image_data["artifacts"]:
+                mime_type, image_artifact = self.download_image_artifact(artifact_data)
+                image_artifacts[mime_type] = image_artifact
+
+            rootfs = [image_artifacts['application/vnd.cray.image.rootfs.squashfs']] \
+                if image_artifacts.get('application/vnd.cray.image.rootfs.squashfs') else None
+            kernel = [image_artifacts['application/vnd.cray.image.kernel']] \
+                if image_artifacts.get('application/vnd.cray.image.kernel') else None
+            initrd = [image_artifacts['application/vnd.cray.image.initrd']] \
+                if image_artifacts.get('application/vnd.cray.image.initrd') else None
+            boot_parameters = [image_artifacts['application/vnd.cray.image.parameters.boot']] \
+                if image_artifacts.get('application/vnd.cray.image.parameters.boot') else None
+
+            ih_upload_kwargs = {
+                'image_name': image_name,
+                'rootfs': rootfs,
+                'kernel': kernel,
+                'initrd': initrd,
+                'boot_parameters': boot_parameters
+            }
+
+            try:
+                result = ih.image_upload_artifacts(**ih_upload_kwargs)
+                if os.environ.get("CREATE_BOS_SESSION_TEMPLATE", "False").lower() in ['true', 'on', 'yes', 't', '1']:
+                    try:
+                        LOGGER.info('Creating BOS Session Temnplate for image "%s"', image_name)
+                        ims_etag = result["ims_image_record"]["link"]["etag"]
+                        ims_image_path = result["ims_image_record"]["link"]["path"]
+                        ims_image_id = result["ims_image_record"]["id"]
+                        self.create_bos_session_template(ims_etag, ims_image_path, ims_image_id)
+                    except KeyError as exc:
+                        LOGGER.error("Error creating BOS Session Template. IMS image result missing variable %s. %s",
+                                     exc, result)
+                return result
+            except requests.RequestException as exc:
+                if hasattr(exc, "response"):
+                    LOGGER.warning("IMS Service Response is %s", exc.response.text)
+                else:
+                    LOGGER.warning(exc)
+            except (botocore.exceptions.BotoCoreError,
+                    ImsLoadArtifactsDownloadException,
+                    ImsLoadArtifactsFileNotFoundException) as exc:
+                LOGGER.warning(exc)
+                ret_value = False
+
+        except (requests.RequestException, ImsLoadArtifactsDownloadException,
+                ImsLoadArtifactsFileNotFoundException) as exc:
+            LOGGER.warning("Error downloading image %s. %s", image_name, str(exc))
+            ret_value = False
+
+        except ValueError as exc:
+            LOGGER.warning("Malformed image %s in manifest. Missing image value. %s", image_name, str(exc))
+            ret_value = False
+
+        return ret_value
+
+    def load_images(self, manifest_data):
+        """ Process IMS images listed in the manifest file. """
+
+        ret_value = True
+        image_results = {'images': {}}
+
+        ih = ImsHelper(
+            ims_url=IMS_URL,
+            session=self.session,
+            s3_endpoint=S3_ENDPOINT,
+            s3_secret_key=S3_SECRET_KEY,
+            s3_access_key=S3_ACCESS_KEY,
+            s3_ssl_verify=S3_SSL_VERIFY,
+            s3_bucket=S3_BOOT_IMAGES_BUCKET
+        )
+
+        if "images" in manifest_data:
+            for image_name, image_data in manifest_data["images"].items():
+                image_result = self.load_image(ih, image_name, image_data)
+                if image_result:
+                    image_results['images'][image_name] = {
+                        'id': image_result['ims_image_record']['id']
+                    }
+                else:
+                    ret_value = False
+
+        if ret_value:
+            return image_results
+
+        return ret_value
+
+    def __call__(self, manifest_data):
+        """ Process IMS recipes and images listed in the manifest file. """
+        ret_recipes = self.load_recipes(manifest_data)
+        ret_images = self.load_images(manifest_data)
+
+        # If everything was successful, write out the results
+        if all([ret_recipes, ret_images]):
+            records = dict(ret_recipes, **ret_images)
+            LOGGER.info(yaml.dump(records))
+            with open('/results/records.yaml', 'wt', encoding='utf-8') as results_file:
+                yaml.dump(records, results_file)
+
+        # Return a boolean of if everything was successful
+        return all([ret_recipes, ret_images])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Only use Cray-procured packages
---extra-index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
+--extra-index-url https://artifactory.algol60.net/artifactory/csm-python-modules/simple
 --trusted-host artifactory.algol60.net
 -c constraints.txt
 

--- a/tests/test_iuf.py
+++ b/tests/test_iuf.py
@@ -1,0 +1,258 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Tests for IUF support
+"""
+import os
+from textwrap import dedent
+from unittest.mock import patch, mock_open
+
+import pytest
+import yaml
+
+from ims_load_artifacts.iuf import (
+    process_content_dir_manifest,
+    process_content_dirs,
+    process_enumerated_manifest,
+    process_iuf_manifest,
+)
+
+iuf_manifest_image_name = 'shasta_barebones_image-1.2.4'
+iuf_manifest_recipe_name = 'shasta_barebones_recipe-1.2.4'
+iuf_content_dir = '/mnt/path/in/container'
+
+squashfs_path = f'{iuf_manifest_image_name}.squashfs'
+kernel_path = f'{iuf_manifest_image_name}.kernel'
+initrd_path = f'{iuf_manifest_image_name}.initrd'
+recipe_path = f'{iuf_manifest_recipe_name}.tgz'
+ims_artifacts_dir = 'ims'
+
+content_dir_image_name = f'content-dir-{iuf_manifest_image_name}'
+content_dir_recipe_name = f'content-dir-{iuf_manifest_recipe_name}'
+content_dir_path = 'ims-content'
+md5sum = 'f3287b5d1267da964cf30fb5910d3126'
+
+
+processed_iuf_images = {
+    iuf_manifest_image_name: {
+        'artifacts': [
+            {
+                'link': {
+                    'path': os.path.join(iuf_content_dir, ims_artifacts_dir, squashfs_path),
+                    'type': 'file'
+                },
+                'md5': md5sum,
+                'type': 'application/vnd.cray.image.rootfs.squashfs'
+            },
+            {
+                'link': {
+                    'path': os.path.join(iuf_content_dir, ims_artifacts_dir, kernel_path),
+                    'type': 'file'
+                },
+                'md5': md5sum,
+                'type': 'application/vnd.cray.image.kernel'
+            },
+            {
+                'link': {
+                    'path': os.path.join(iuf_content_dir, ims_artifacts_dir, initrd_path),
+                    'type': 'file'
+                },
+                'md5': md5sum,
+                'type': 'application/vnd.cray.image.initrd'
+            },
+        ]
+    }
+}
+
+
+@pytest.fixture
+def content_dir_manifest():
+    return dedent(f"""\
+    ---
+    version: "1.0.0"
+    images:
+      {content_dir_image_name}:
+        artifacts:
+          - link:
+              path: /{squashfs_path}
+              type: file
+            md5: {md5sum}
+            type: application/vnd.cray.image.rootfs.squashfs
+          - link:
+              path: /{kernel_path}
+              type: file
+            md5: {md5sum}
+            type: application/vnd.cray.image.kernel
+          - link:
+              path: /{initrd_path}
+              type: file
+            md5: {md5sum}
+            type: application/vnd.cray.image.initrd
+    recipes:
+      {content_dir_recipe_name}:
+        link:
+          path: /{recipe_path}
+          type: file
+        md5: {md5sum}
+        linux_distribution: sles15
+        recipe_type: kiwi-ng
+    """)
+
+
+@pytest.fixture
+def content_dir_manifest_only_recipes():
+    return dedent(f"""\
+    ---
+    version: "1.0.0"
+    recipes:
+      {content_dir_recipe_name}:
+        link:
+          path: /{recipe_path}
+          type: file
+        md5: {md5sum}
+        linux_distribution: sles15
+        recipe_type: kiwi-ng
+    """)
+
+
+@pytest.fixture
+def enumerated_iuf_manifest():
+    return dedent(f"""\
+    ---
+    name: shasta_barebones
+    description: >
+      A barebones IMS recipe and image.
+    version: "1.0.0"
+    content:
+      ims:
+        recipes:
+        - name: {iuf_manifest_recipe_name}
+          path: {recipe_path}
+          linux_distribution: sles15
+          recipe_type: kiwi-ng
+          template_dictionary:
+            product_version: "22.12"
+          md5sum: {md5sum}
+        images:
+        - name: {iuf_manifest_image_name}
+          path: {ims_artifacts_dir}
+          rootfs:
+            path: {squashfs_path}
+            md5sum: {md5sum}
+          kernel:
+            path: {kernel_path}
+            md5sum: {md5sum}
+          initrd:
+            md5sum: {md5sum}
+            path: {initrd_path}
+    """)
+
+
+@pytest.fixture
+def mixed_iuf_manifest():
+    return dedent(f"""\
+    ---
+    name: shasta_barebones
+    description: >
+      A barebones IMS recipe and image
+    version: 1.0.0
+    content:
+      ims:
+        content_dirs:
+        - {content_dir_path}
+        images:
+        - name: {iuf_manifest_image_name}
+          path: {ims_artifacts_dir}
+          rootfs:
+            path: {squashfs_path}
+            md5sum: {md5sum}
+          kernel:
+            path: {kernel_path}
+            md5sum: {md5sum}
+          initrd:
+            md5sum: {md5sum}
+            path: {initrd_path}
+    """)
+
+
+def test_process_content_dir_manifest(content_dir_manifest):
+    """Test that artifact paths are correctly re-written"""
+    manifest_parsed = yaml.safe_load(content_dir_manifest)
+    new_manifest = process_content_dir_manifest(manifest_parsed, iuf_content_dir)
+
+    assert new_manifest['recipes'][content_dir_recipe_name]['link']['path'] == os.path.join(iuf_content_dir, recipe_path)
+    for idx, expected_path in enumerate([os.path.join(iuf_content_dir, path) for path in [squashfs_path, kernel_path, initrd_path]]):
+        assert new_manifest['images'][content_dir_image_name]['artifacts'][idx]['link']['path'] == expected_path
+
+
+def test_process_content_dirs(content_dir_manifest):
+    """Test that content dirs are opened and processed properly"""
+    with patch('builtins.open', mock_open(read_data=content_dir_manifest)):
+        manifest = process_content_dirs([iuf_content_dir], iuf_content_dir)
+    assert process_content_dir_manifest(yaml.safe_load(content_dir_manifest), iuf_content_dir) == manifest
+
+
+def test_mixed_manifest(content_dir_manifest_only_recipes, mixed_iuf_manifest):
+    """Test a manifest with content dirs and enumerated artifacts"""
+    with patch('builtins.open', mock_open(read_data=content_dir_manifest_only_recipes)):
+        manifest = yaml.safe_load(mixed_iuf_manifest)
+        processed_manifest = process_iuf_manifest(manifest, iuf_content_dir)
+        expected_manifest = {
+            'version': '1.0.0',
+            'recipes': {
+                content_dir_recipe_name: {  # The recipes are in the content dir, not the IUF manifest
+                    'link': {
+                        'type': 'file',
+                        'path': os.path.join(iuf_content_dir, content_dir_path, recipe_path),
+                    },
+                    'linux_distribution': 'sles15',
+                    'recipe_type': 'kiwi-ng',
+                    'md5': md5sum
+                }
+            },
+            'images': processed_iuf_images
+        }
+        assert processed_manifest == expected_manifest
+
+
+def test_processing_enumerated_iuf_manifest(enumerated_iuf_manifest):
+    manifest = yaml.safe_load(enumerated_iuf_manifest)
+    recipes = manifest['content']['ims']['recipes']
+    images = manifest['content']['ims']['images']
+    assert process_enumerated_manifest(recipes, images, iuf_content_dir) == {
+        'version': '1.0.0',
+        'recipes': {
+            iuf_manifest_recipe_name: {
+                'link': {
+                    'type': 'file',
+                    'path': os.path.join(iuf_content_dir, recipe_path)
+                },
+                'linux_distribution': 'sles15',
+                'recipe_type': 'kiwi-ng',
+                'template_dictionary': {'product_version': '22.12'},
+                'md5': md5sum
+            }
+        },
+        'images': processed_iuf_images
+    }

--- a/tests/test_load_artifacts.py
+++ b/tests/test_load_artifacts.py
@@ -39,6 +39,7 @@ import testtools
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')))
 
 from ims_load_artifacts import load_artifacts
+from ims_load_artifacts import loaders
 
 manifest_yaml = """
 ---
@@ -76,7 +77,7 @@ class TestLoadArtifacts(testtools.TestCase):
 
     @responses.activate
     @mock.patch(".".join([load_artifacts.__name__, "yaml.dump"]))
-    @mock.patch(".".join([load_artifacts.__name__, "open"]), new_callable=mock.mock_open, read_data=manifest_yaml)
+    @mock.patch('builtins.open', new_callable=mock.mock_open, read_data=manifest_yaml)
     def test_init(self, mock_open, mock_yaml_dump):
 
         S3_ACCESS_KEY = self.getUniqueString()
@@ -119,7 +120,7 @@ class TestLoadArtifacts(testtools.TestCase):
             'S3_BUCKET', S3_BUCKET))
 
         ih_mock = self.useFixture(fixtures.MockPatchObject(
-            load_artifacts, 'ImsHelper', autospec=True)).mock
+            loaders, 'ImsHelper', autospec=True)).mock
 
         ih_mock._md5.return_value = "f3287b5d1267da964cf30fb5910d3126"
 


### PR DESCRIPTION
## Summary and Scope
This change adds support for the IUF in the `load-ims-artifacts` image in order to implement the ims-upload operation. It requires that the IUF release distribution be mounted within the container, and that the `IUF` and `IUF_RELEASE_PATH` environment variables be set. Other environment variables must be set within the container as normal.

Existing `load-ims-artifacts` images should still be compatible with this change. Additionally, `manifest.yaml` files from existing `load-ims-artifacts` images can be used with the IUF ims-upload operation, maintaining backwards compatibility.

## Issues and Related PRs

* Resolves [CRAYSAT-3506](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3506)

## Testing

### Tested on:

  * `frigg`, `mug`
  * Local development environment

### Test description:

Run IUF workflows using enumerated IUF manifests and existing content directories. Ensure that content is uploaded as expected.

## Risks and Mitigations

Does not affect existing implementation.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

