### PR TITLE
CASMINST-5443: Authenticate to CSM's artifactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Authenticate to CSM's artifactory
 
 ## [1.6.1] - 2022-10-05
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@
 
 FROM artifactory.algol60.net/docker.io/alpine:3.15 as base
 COPY requirements.txt constraints.txt /
-RUN apk add --upgrade --no-cache apk-tools &&  \
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+        apk add --upgrade --no-cache apk-tools &&  \
 	apk update && \
 	apk add --no-cache \
         gcc \

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -40,6 +40,7 @@ pipeline {
         NAME = "cray-ims-load-artifacts"
         DESCRIPTION = "Load prebuilt images and recipes into the cray IMS service"
         IS_STABLE = getBuildIsStable()
+	DOCKER_BUILDKIT = "1"
     }
 
     stages {

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@
 NAME ?= ims-load-artifacts
 DOCKER_VERSION ?= $(shell head -1 .docker_version)
 
+ifneq ($(wildcard ${HOME}/.netrc),)
+        DOCKER_ARGS ?= --secret id=netrc,src=${HOME}/.netrc
+endif
+
 all : runbuildprep lint image 
 
 runbuildprep:


### PR DESCRIPTION
## Summary and Scope

Authenticate to CSM's artifactory when using pip to access CSM's csm-python-modules.


## Issues and Related PRs


* Resolves CASMINST-5443

## Testing


### Tested on:

  * Build environment

### Test description:

It builds successfully.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

