### PR TITLE
Casminst 5443 csm 1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@
 
 FROM artifactory.algol60.net/docker.io/alpine:3.15 as base
 COPY requirements.txt constraints.txt /
-RUN apk add --upgrade --no-cache apk-tools &&  \
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+        apk add --upgrade --no-cache apk-tools &&  \
 	apk update && \
 	apk add --no-cache \
         gcc \

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -15,6 +15,7 @@ pipeline {
         NAME = "cray-ims-load-artifacts"
         DESCRIPTION = "Load prebuilt images and recipes into the cray IMS service"
         IS_STABLE = getBuildIsStable()
+	DOCKER_BUILDKIT = "1"
     }
 
     stages {

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,6 +25,10 @@
 
 NAME ?= ims-load-artifacts
 DOCKER_VERSION ?= $(shell head -1 .docker_version)
+
+ifneq ($(wildcard ${HOME}/.netrc),)
+        DOCKER_ARGS ?= --secret id=netrc,src=${HOME}/.netrc
+endif
 
 all : runbuildprep lint image 
 


### PR DESCRIPTION
## Summary and Scope

Authenticate to CSM's artifactory when using pip to access CSM's csm-python-modules.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-5443

## Testing


### Tested on:

  * Tested by committing it to the build environment. There was not an artifactory available with the correct permissions to test against.

### Test description:

See above.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No.
- Were continuous integration tests run? If not, why? No.
- Was upgrade tested? If not, why? No.
- Was downgrade tested? If not, why? No.
- Were new tests (or test issues/Jiras) created for this change? No.

## Risks and Mitigations
Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

