### PR TITLE
CASM-3760: Skip exising images with duplicate names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## Unreleased
+### Changed
+- Use `ims-python-helper>=2.11.0` to prevent new images from being
+  created with a duplicate name in the IUF.
+
+## [2.1.0] - 2023-02-03
 ### Fixed
 - CASMINST-5843: Update the nobody user in Dockerfile to own the `/etc/ssl/certs` directory to allow `update-ca-certificates` to add user certificates.
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,7 +4,7 @@ certifi==2019.11.28
 chardet==3.0.4
 docutils==0.14
 idna==2.8
-ims-python-helper>=2.10.0
+ims-python-helper>=2.11.0
 jmespath==0.9.4
 oauthlib==2.1.0
 python-dateutil==2.8.1

--- a/ims_load_artifacts/loaders.py
+++ b/ims_load_artifacts/loaders.py
@@ -332,6 +332,9 @@ class ImsLoadArtifacts_v1_0_0:
                 'initrd': initrd,
                 'boot_parameters': boot_parameters
             }
+            if os.getenv('IUF'):
+                # Only skip images with the same name when running in an IUF context.
+                ih_upload_kwargs['skip_existing'] = True
 
             try:
                 result = ih.image_upload_artifacts(**ih_upload_kwargs)


### PR DESCRIPTION

## Summary and Scope

This change bumps the version of the `ims-python-helper` dependency to pull in functionality which allows skipping uploading IMS images which already exist with the same name. A small change was also made to `ImsLoadArtifacts_v1_0_0.load_image()` to accomodate this change.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASM-3760](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3760)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

