### PR TITLE
CASMINST-5843: Add cert permissions for nobody user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
-- CASMINST-5843: Update> the nobody user in Dockerfile to own the `/etc/ssl/certs` directory to allow `update-ca-certificates` to add user certificates.
+### Fixed
+- CASMINST-5843: Update the nobody user in Dockerfile to own the `/etc/ssl/certs` directory to allow `update-ca-certificates` to add user certificates.
 
 ## [2.0.1] - 2022-12-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- CASMINST-5843: Update> the nobody user in Dockerfile to own the `/etc/ssl/certs` directory to allow `update-ca-certificates` to add user certificates.
 
 ## [2.0.1] - 2022-12-20
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ COPY requirements.txt constraints.txt /
 RUN --mount=type=secret,id=netrc,target=/root/.netrc \
         apk add --upgrade --no-cache apk-tools &&  \
 	apk update && \
-	apk add --no-cache \
+	apk add --update --no-cache \
+        ca-certificates \
         gcc \
         python3-dev \
         libc-dev \
@@ -63,7 +64,11 @@ FROM base as application
 RUN mkdir -p /ims_load_artifacts /results && \
   chown -R "nobody:nobody" /ims_load_artifacts /results
 
+# For update-ca-certificates at runtime
+RUN chown nobody:nobody /etc/ssl/certs
+
 ENV PYTHONPATH="/"
 USER nobody
 COPY ims_load_artifacts /ims_load_artifacts
+ADD argo_entrypoint.sh /ims_load_artifacts
 ENTRYPOINT ["/ims_load_artifacts/load_artifacts.py"]

--- a/argo_entrypoint.sh
+++ b/argo_entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# MIT License
+#
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+set -e
+
+#
+# update-ca-certificates reads from /usr/local/share/ca-certificates
+# and updates /etc/ssl/certs/ca-certificates.crt
+# REQUESTS_CA_BUNDLE is used by python
+#
+export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+update-ca-certificates --fresh 2>/dev/null
+
+python3 -m ims_load_artifacts.load_artifacts


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

- Adds argo specific entrypoint

IUF needs to add support for `update-ca-certificates` so that the nobody user can mount cluster certs at runtime.
This will allow current `ims-upload` argo template implementation to remove use of subPath mounts in K8s. This is
a critical issue where the cleanup of the mounts will bog down a system over time.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-5843](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5843)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `frigg`

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

