### PR TITLE
CASMINST-5926: Update ims-python-helper dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2023-02-07
+### Changed
+- Use `ims-python-helper>=2.11.1` to fix `KeyError` bug when finding duplicate
+  IMS images.
 
 ## [2.2.0] - 2023-02-03
 ### Changed

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,7 +4,7 @@ certifi==2019.11.28
 chardet==3.0.4
 docutils==0.14
 idna==2.8
-ims-python-helper>=2.11.0
+ims-python-helper>=2.11.1
 jmespath==0.9.4
 oauthlib==2.1.0
 python-dateutil==2.8.1


### PR DESCRIPTION

## Summary and Scope
The update to the ims-python-helper dependency is needed to fix a KeyError when uploading an image with a name that already exists in IMS.

## Issues and Related PRs

* Resolves [CASMINST-5926](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5926)


## Testing

### Tested on:

  * `frigg`

### Test description:
Test on frigg by uploading test data with test harness as described in this PR: https://github.com/Cray-HPE/ims-python-helper/pull/27


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

