### PR TITLE
CASM-3868: Update version of ims-python-helper to 2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2023-04-18
+### Changed
+- Use `ims-python-helper>=2.12.0` to use artifact checksums to determine equality
+  of IMS images and recipes.
+
 ## [2.2.1] - 2023-02-07
 ### Changed
 - Use `ims-python-helper>=2.11.1` to fix `KeyError` bug when finding duplicate

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,7 +4,7 @@ certifi==2019.11.28
 chardet==3.0.4
 docutils==0.14
 idna==2.8
-ims-python-helper>=2.11.1
+ims-python-helper>=2.12.0
 jmespath==0.9.4
 oauthlib==2.1.0
 python-dateutil==2.8.1


### PR DESCRIPTION
## Summary and Scope
Update ims-python-helper library version to 2.12.00 to pull in change which checks artifact checksums to determine image and recipe equality.

## Issues and Related PRs

* Resolves [CASM-3868](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3868)

## Testing

Testing performed on ims-python-helper library.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

