### PR TITLE
CASMCMS-8646: Follow (unenforced) restrictions on BOS session template names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- BOS session templates that are created now follow BOS's stated (but currently unenforced)
+  restrictions on template names.
+  
 ### Removed
 - Removed defunct files leftover from previous versioning system
 

--- a/ims_load_artifacts/loaders.py
+++ b/ims_load_artifacts/loaders.py
@@ -129,7 +129,7 @@ class ImsLoadArtifacts_v1_0_0:
             bos_session_template = Template(self.BOS_SESSION_TEMPLATE).substitute({
                 "ims_etag": ims_etag,
                 "ims_manifest_path": ims_manifest_path,
-                "ims_image_name": f'"IMS Id: {ims_image_id}"',
+                "ims_image_name": f'"ims-id-{ims_image_id}"',
                 'bos_kernel_parameters': BOS_KERNEL_PARAMETERS,
                 'bos_rootfs_provider': BOS_ROOTFS_PROVIDER,
                 'bos_rootfs_provider_passthrough': BOS_ROOTFS_PROVIDER_PASSTHROUGH,


### PR DESCRIPTION
## Summary and Scope

Specifically, change the name used so that it does not include capital letters, spaces, or colons (all of which are supposed to be forbidden in BOS session template names, even though BOS kindly looks the other way about such transgressions). So the BOS session templates which currently are named like this:

`IMS Id: 52ab5697-f5b7-4140-85ee-b77a1e3709da`

will now be named like this:

`ims-id-52ab5697-f5b7-4140-85ee-b77a1e3709da`

## Issues and Related PRs

* Resolves [CASMCMS-8646](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8646)
* Related to [CASMCMS-8448](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8448)

## Risks and Mitigations

Very low risk -- just using a different name for the session template. I searched all CASM repositories for references to the current naming schema, to make sure that this change would not break any existing tools. It's possible something was overlooked, but since this is for CSM 1.5, hopefully we will discover this quickly once this is in a build. In any case, the fix would be very simple -- just update whatever thing is failing to use the new naming convention.

Making this change is necessary if we ever do want to start enforcing the naming restrictions. And it will be good to not have customers seeing CSM itself flaunting its own ostensible rules.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
