### PR TITLE
CASMCMS-7922: Create BOS session templates using BOS v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Default to creating BOS session templates using BOS v2 instead of BOS v1. Add support for new `BOS_SESSIONTEMPLATES_ENDPOINT`
+  environment variable, reflecting corresponding change in the [`cray-import-kiwi-recipe-image`](https://github.com/Cray-HPE/cray-import-kiwi-recipe-image)
+  repository.
 
 ## [2.4.0] - 2023-05-23
 ### Changed


### PR DESCRIPTION
## Summary and Scope

Currently when `ims-load-artifacts` creates BOS session templates, it does so using BOS v1. This PR modifies it so that by default it will create using BOS v2. However, it still leaves open a method for users of this package to use BOS v1, if desired.

[A recent change](https://github.com/Cray-HPE/cray-import-kiwi-recipe-image/pull/18) in [the cray-import-kiwi-recipe-image repository](https://github.com/Cray-HPE/cray-import-kiwi-recipe-image) changed the `BOS_SESSION_ENDPOINT` to be `BOS_SESSIONTEMPLATES_ENDPOINT`, and the new value of the variable is the location of the BOS v2 session template endpoint.

This PR modifies the ims-load-artifacts logic as follows:
- If the new `BOS_SESSIONTEMPLATES_ENDPOINT` variable is specified, assume that BOS v2 is being used, and use the provided endpoint during session template creation. Otherwise,
- If the old `BOS_SESSION_ENDPOINT` variable is specified, assume that BOS v1 is being used, and use the provided endpoint during session template creation. Otherwise,
- If neither is specified, use BOS v2 with the default value for the BOS v2 session templates endpoint.

Using BOS v2 instead of v1 entailed a few changes:
* Changing the POST to a PUT
* Removing the template name from the template body itself and instead putting it in the URL
* Removing v1-specific fields from the template being created.

The change from BOS v1 to v2 should be invisible to external users, except that the resulting session templates will no longer have the v1-specific bootset fields "network" and "boot_ordinal" (which won't make a difference in the behavior of this template).

## Issues and Related PRs

* Partially resolves [CASMCMS-7922](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-7922)
* After this PR merges to develop, and develop is merged to master, and tagged as v2.5.0, then [this PR](https://github.com/Cray-HPE/image-recipes/pull/56) is ready to be merged, pending approvals.

## Testing

I tested this on lemondrop. I re-created one of the BOS session templates currently on the system that was created using ims-load-artifacts. Here is the original version:

```json
{
  "boot_sets": {
    "compute": {
      "boot_ordinal": 2,
      "etag": "c356a0bf6cc3d285a4bc6ff6910e4e8c",
      "kernel_parameters": "console=ttyS0,115200 bad_page=panic crashkernel=340M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable iommu=pt ip=dhcp numa_interleave_omit=headless numa_zonelist_order=node oops=panic pageblock_order=14 pcie_ports=native printk.synchronous=y rd.neednet=1 rd.retry=10 rd.shell turbo_boost_limit=999 spire_join_token=${SPIRE_JOIN_TOKEN}",
      "network": "nmn",
      "node_roles_groups": [
        "Compute"
      ],
      "path": "s3://boot-images/94b3c006-1150-4a3b-8ef8-7a96000fbead/manifest.json",
      "rootfs_provider": "cpss3",
      "rootfs_provider_passthrough": "dvs:api-gw-service-nmn.local:300:nmn0",
      "type": "s3"
    }
  },
  "cfs": {
    "configuration": ""
  },
  "enable_cfs": false,
  "name": "IMS Id: 94b3c006-1150-4a3b-8ef8-7a96000fbead"
}
```

And here is the version created with this PR with the `BOS_SESSIONTEMPLATES_ENDPOINT` specified (I also verified I got the same result if nothing was specified, and if both variables were specified).

```json
{
  "boot_sets": {
    "compute": {
      "etag": "c356a0bf6cc3d285a4bc6ff6910e4e8c",
      "kernel_parameters": "console=ttyS0,115200 bad_page=panic crashkernel=340M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable iommu=pt ip=dhcp numa_interleave_omit=headless numa_zonelist_order=node oops=panic pageblock_order=14 pcie_ports=native printk.synchronous=y rd.neednet=1 rd.retry=10 rd.shell turbo_boost_limit=999 spire_join_token=${SPIRE_JOIN_TOKEN}",
      "node_roles_groups": [
        "Compute"
      ],
      "path": "s3://boot-images/94b3c006-1150-4a3b-8ef8-7a96000fbead/manifest.json",
      "rootfs_provider": "cpss3",
      "rootfs_provider_passthrough": "dvs:api-gw-service-nmn.local:300:nmn0",
      "type": "s3"
    }
  },
  "cfs": {
    "configuration": ""
  },
  "enable_cfs": false,
  "name": "ims-id-94b3c006-1150-4a3b-8ef8-7a96000fbead"
}
```

The name is different because of [an earlier update to ims-load-artifacts](https://github.com/Cray-HPE/ims-load-artifacts/pull/56).

Otherwise, as you can see, the only difference is that the v1-specific bootset fields are no longer included.

Finally, here is the version created with only `BOS_SESSION_ENDPOINT` specified:

```json
{
  "boot_sets": {
    "compute": {
      "boot_ordinal": 2,
      "etag": "c356a0bf6cc3d285a4bc6ff6910e4e8c",
      "kernel_parameters": "console=ttyS0,115200 bad_page=panic crashkernel=340M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable iommu=pt ip=dhcp numa_interleave_omit=headless numa_zonelist_order=node oops=panic pageblock_order=14 pcie_ports=native printk.synchronous=y rd.neednet=1 rd.retry=10 rd.shell turbo_boost_limit=999 spire_join_token=${SPIRE_JOIN_TOKEN}",
      "network": "nmn",
      "node_roles_groups": [
        "Compute"
      ],
      "path": "s3://boot-images/94b3c006-1150-4a3b-8ef8-7a96000fbead/manifest.json",
      "rootfs_provider": "cpss3",
      "rootfs_provider_passthrough": "dvs:api-gw-service-nmn.local:300:nmn0",
      "type": "s3"
    }
  },
  "cfs": {
    "configuration": ""
  },
  "enable_cfs": false,
  "name": "ims-id-94b3c006-1150-4a3b-8ef8-7a96000fbead"
}
```

As you can see, identical to the original except for the name.

## Risks and Mitigations

Low risk. BOS v2 has not been new for a while now. Creating and using its session templates are well tested.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

