### PR TITLE
CASMCMS-8713: Bump PyYAML from 5.4.1 to 6.0.1 to prevent build issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [2.6.1] - 2023-07-18
+### Dependencies
+- Bump `PyYAML` from 5.4.1 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601
 
 ## [2.6.0] - 2023-06-13
 ### Changed

--- a/constraints.txt
+++ b/constraints.txt
@@ -8,7 +8,7 @@ ims-python-helper==0.0.0-imspython
 jmespath==0.9.4
 oauthlib==2.1.0
 python-dateutil==2.8.1
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.23.0
 requests-oauthlib==1.0.0
 s3transfer==0.3.0


### PR DESCRIPTION
Builds in this repo are failing due to the problem documented in [CASMCMS-8713](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8713). Moving to PyYAML 6.0.1 resolves the problem. This PR moves PyYAML from 5.4.1 to 6.0.1.

A similar change is being made to a number of CSM repositories that are similarly affected.