### PR TITLE
CASMCMS-8713: Bump PyYAML from 5.4.1 to 6.0.1 to prevent build issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2023-07-18
+### Dependencies
+- Bump `PyYAML` from 5.4.1 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601
+
 ## [2.2.1] - 2023-02-07
 ### Changed
 - Use `ims-python-helper>=2.11.1` to fix `KeyError` bug when finding duplicate

--- a/constraints.txt
+++ b/constraints.txt
@@ -8,7 +8,7 @@ ims-python-helper>=2.11.1
 jmespath==0.9.4
 oauthlib==2.1.0
 python-dateutil==2.8.1
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.23.0
 requests-oauthlib==1.0.0
 s3transfer==0.3.0


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/ims-load-artifacts/pull/74 to allow support/2.2 branch to be buildable