### PR TITLE
CASMCMS-8743 - Templatize bos kernel parameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+CASMCMS-8743 - templatize the bos kernel parameters.
+
 ### Dependencies
 Bumped dependency patch versions:
 | Package                  | From     | To       |


### PR DESCRIPTION
## Summary and Scope

The MTL barebones boot image requires that the IMS id (boot-images path) be put in the kernel parameters in order to boot correctly. This allows the kernel parameters string to be templatized so that this information can be fed in at the time the bos session templates are created for a particular boot image.

## Issues and Related PRs

* Resolves [CASMCMS-8743](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8743)
* Change will also be needed in other repos.

## Testing
### Tested on:
  * `Mug`

### Test description:

I build image-recipes using this unstable helm chart, built the install service, then did a helm upgrade on Mug. I confirmed the images were imported correctly and each image had a corresponding bos v2 session template created for it.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

