### PR TITLE
CASMCMS-9282: Bump Alpine version from 3.15 to 3.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.0] - 2025-02-13
+### Dependencies
+- CASMCMS-9282: Bump Alpine version from 3.15 to 3.18, because 3.15 no longer receives security patches
+
 ## [2.7.2] - 2024-07-25
 ### Dependencies
 - Resolve CVE by bumping `certifi` from 2019.11.28 to 2023.7.22

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 #
 # Dockerfile for ims-load-artifacts container
 
-FROM artifactory.algol60.net/docker.io/library/alpine:3.15 as base
+FROM artifactory.algol60.net/docker.io/library/alpine:3.18 as base
 COPY requirements.txt constraints.txt /
 RUN --mount=type=secret,id=netrc,target=/root/.netrc \
         apk add --upgrade --no-cache apk-tools &&  \


### PR DESCRIPTION
Alpine 3.15 no longer receives security patches.
Moving to Alpine 3.19+ will require us to rework the Dockerfile to install the Python packages into a virtual environment. This is worth doing, but given that we have to do this Alpine update for a lot of repos, the priority now is expediency and minimizing the risk of causing other problems in the process.