### PR TITLE
CASMCMS-9510: Updated ims-python-helper version to 3.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Dependencies
+- CASMCMS-9510: Updated ims-python-helper version to 3.3.x
+
 ## [2.9.0] - 2025-06-17
 ### Dependencies
 - CASMCMS-8022:  update python modules

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -1,4 +1,4 @@
 image: ims-python-helper
     source: python
     major: 3
-    minor: 2
+    minor: 3


### PR DESCRIPTION
## Summary and Scope
CASMCMS-9510: Updated ims-python-helper version to 3.3.x

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

